### PR TITLE
adding void to to-string

### DIFF
--- a/decode.rkt
+++ b/decode.rkt
@@ -14,6 +14,7 @@
           [(number? x) (number->string x)]
           [(path? x) (path->string x)]
           [(char? x) (format "~a" x)]
+          [(void? x) ""]
           ;; todo: guard against weird shit like lists of procedures
           [(or (list? x) (hash? x) (vector? x)) (format "~v" x)] ; ok to convert datatypes
           [else (error)])))) ; but things like procedures should throw an error


### PR DESCRIPTION
Not sure if I'm "doing it wrong", but this makes some things possible/easier.

Over-simplified example:

```
#lang pollen
◊(define x 4)
◊(define (f x) (set! x 3))
◊(f x)
```

Pollen crashes for this input without the void case.
