### PR TITLE
add color-lexer for #lang pollen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # for Racket
 compiled/
+*~
 
 # for Mac OS X
 .DS_Store

--- a/reader-base.rkt
+++ b/reader-base.rkt
@@ -66,5 +66,11 @@
     (define (get-info in mod line col pos)
       (λ (key default)
         (case key
+          [(color-lexer)
+           (define make-scribble-inside-lexer2
+             (dynamic-require 'syntax-color/scribble-lexer 'make-scribble-inside-lexer (λ () #f)))
+           (cond [make-scribble-inside-lexer2
+                  (make-scribble-inside-lexer2 #:command-char #\◊)]
+                 [else default])]
           [else default])))
     (provide (rename-out [custom-read read] [custom-read-syntax read-syntax]) get-info)))


### PR DESCRIPTION
Now that `(make-scribble-inside-lexer #:command-char #\◊)` exists in Racket version 6.2.
(uses dynamic-require so that it doesn't break it for other versions)