### PR TITLE
Documenting and providing ->source-file, get-doc and get-metas

### DIFF
--- a/scribblings/file.scrbl
+++ b/scribblings/file.scrbl
@@ -11,11 +11,13 @@
 
 A utility module that provides functions for working with Pollen source and output files. The tests rely on file extensions specified in @racket[pollen/world].
 
-Pollen handles six kinds of source files:
+Pollen handles seven kinds of source files:
 
 @bold{Preprocessor}, with file extension @code[(format ".~a" world:preproc-source-ext)]. 
 
 @bold{Markup}, with file extension @code[(format ".~a" world:markup-source-ext)]. 
+
+@bold{Markdown}, with file extension @code[(format ".~a" world:markdown-source-ext)]. 
 
 @bold{Template}, with file extension @code[(format ".~a" world:template-source-ext)]. 
 
@@ -33,6 +35,11 @@ boolean?]
 
 @defproc[
 (markup-source?
+[v any/c]) 
+boolean?]
+
+@defproc[
+(markdown-source?
 [v any/c]) 
 boolean?]
 
@@ -61,6 +68,7 @@ Test whether @racket[_v] is a path representing a source file of the specified t
 @examples[#:eval my-eval
 (preproc-source? "main.css.pp")
 (markup-source? "default.html.pm")
+(markdown-source? "default.html.pmd")
 (template-source? "main.html.pt")
 (null-source? "index.html.p")
 (scribble-source? "file.scrbl")
@@ -77,6 +85,11 @@ boolean?]
 
 @defproc[
 (has-markup-source?
+[v any/c]) 
+boolean?]
+
+@defproc[
+(has-markdown-source?
 [v any/c]) 
 boolean?]
 
@@ -113,6 +126,11 @@ boolean?]
 boolean?]
 
 @defproc[
+(has/is-markdown-source?
+[v any/c]) 
+boolean?]
+
+@defproc[
 (has/is-template-source?
 [v any/c]) 
 boolean?]
@@ -142,6 +160,11 @@ path?]
 path?]
 
 @defproc[
+(->markdown-source-path
+[p pathish?]) 
+path?]
+
+@defproc[
 (->template-source-path
 [p pathish?]) 
 path?]
@@ -162,13 +185,19 @@ Convert an output path @racket[_p] into the source path of the specified type th
 (define name "default.html")
 (->preproc-source-path name)
 (->markup-source-path name)
+(->markdown-source-path name)
 (->template-source-path name)
 (->scribble-source-path name)
 (->null-source-path name)
 ]
 
+Convert an output path @racket[_p] into the source path of the specified type that would produce this output path. This function simply generates a path for a file — it does not ask whether the file exists.
 
-
+@defproc[
+(->source-path
+[p pathish?]) 
+(or/c #f path?)]
+Attempt to automatically convert an output path @racket[_p] into its source path. This function checks for the existence of the path with the extensions for markup, markdown, preprocessor, null, and scribble files.
 
 @defproc[
 (->output-path

--- a/scribblings/file.scrbl
+++ b/scribblings/file.scrbl
@@ -197,7 +197,7 @@ Convert an output path @racket[_p] into the source path of the specified type th
 (->source-path
 [p pathish?]) 
 (or/c #f path?)]
-Attempt to automatically convert an output path @racket[_p] into its source path. This function checks for the existence of the path with the extensions for markup, markdown, preprocessor, null, and scribble files.
+Attempt to automatically convert an output path @racket[_p] into its source path. This function checks for the existence of the path with the extensions for markup, markdown, preprocessor, null, and scribble files. If there are no matches, then @racket[#f] is returned.
 
 @defproc[
 (->output-path

--- a/scribblings/template.scrbl
+++ b/scribblings/template.scrbl
@@ -138,6 +138,13 @@ Note that if @racket[_meta-source] is a relative path or pagenode, it is treated
 (select-from-metas 'nonexistent-key metas)
 ]
 
+@defproc[
+(get-metas
+[source-file (or/c pagenode? pathish?)])
+hash?]
+Retrieve the @racket[metas] hashtable from @racket[_file-source]. The @racket[_file-source] argument can be either a pagenode or source path that identifies a source file that provides @racket[metas]. If @racket[_file-source] does not exist, an error is thrown.
+
+Note that if @racket[_source-file] is a relative path or pagenode, it is treated as being relative to @racket[world:current-project-root]. If that's not what you want, you'll need to convert it explicitly to a complete-path (e.g., with @racket[path->complete-path] or @racket[->complete-path]).
 
 
 @defproc[
@@ -159,6 +166,15 @@ Note that if @racket[_doc-source] is a relative path or pagenode, it is treated 
 ('answer . select-from-doc . doc)
 (select-from-doc 'nonexistent-key doc)
 ]
+
+@defproc[
+(get-doc
+[source-file (or/c pagenode? pathish?)])
+(or/c txexpr? string?)]
+Retrieve the @racket[_doc] from @racket[_file-source]. The @racket[_file-source] argument can be either a pagenode or source path that identifies a source file that provides @racket[metas]. If @racket[_file-source] does not exist, an error is thrown.
+
+Note that if @racket[_source-file] is a relative path or pagenode, it is treated as being relative to @racket[world:current-project-root]. If that's not what you want, you'll need to convert it explicitly to a complete-path (e.g., with @racket[path->complete-path] or @racket[->complete-path]).
+
 
 @defproc[
 (when/block

--- a/template.rkt
+++ b/template.rkt
@@ -11,7 +11,7 @@
   (path->pagenode (or (select-from-metas (world:current-here-path-key) metas) 'unknown)))
 
 
-(define (pagenode->path pagenode)
+(define+provide (pagenode->path pagenode)
   (build-path (world:current-project-root) (symbol->string pagenode)))
 
 
@@ -80,8 +80,8 @@
   (check-false (select-from-doc 'absent-key  doc))))
 
 
-(define (get-metas pagenode-or-path)
-  ;  ((or/c pagenode? pathish?) . -> . hash?)
+(define+provide/contract (get-metas pagenode-or-path)
+  ((or/c pagenode? pathish?) . -> . hash?)
   (define source-path (->source-path (cond
                                        [(pagenode? pagenode-or-path) (pagenode->path pagenode-or-path)]
                                        [else pagenode-or-path])))
@@ -90,8 +90,8 @@
       (error (format "get-metas: no source found for '~a' in directory ~a" pagenode-or-path (current-directory)))))
 
 
-(define (get-doc pagenode-or-path)
-  ;  ((or/c pagenode? pathish?) . -> . (or/c txexpr? string?))
+(define+provide/contract (get-doc pagenode-or-path)
+  ((or/c pagenode? pathish?) . -> . (or/c txexpr? string?))
   (define source-path (->source-path (cond
                                        [(pagenode? pagenode-or-path) (pagenode->path pagenode-or-path)]
                                        [else pagenode-or-path])))


### PR DESCRIPTION
Pollen users cannot easily retrieve the `doc` from their files without reiterating a bunch of code already used inside of Pollen. So, I documented the existing function `->source-path` and provided, contracted and documented `get-doc` and `get-metas`. 