### PR TITLE
Fix consistency of using `compose1'

### DIFF
--- a/pollen/scribblings/tutorial-third.scrbl
+++ b/pollen/scribblings/tutorial-third.scrbl
@@ -819,7 +819,7 @@ Here, we'll use the @filepath{pollen.rkt} we devised in the previous section to 
 (define (root . elements)
    (txexpr 'root empty (decode-elements elements
      #:txexpr-elements-proc decode-paragraphs
-     #:string-proc (compose smart-quotes smart-dashes))))
+     #:string-proc (compose1 smart-quotes smart-dashes))))
 }]
 
 


### PR DESCRIPTION
Previously, on the tutorial, `compose1` is used and explained. Furthermore, the [documentation on `compose/compose1`](http://docs.racket-lang.org/reference/procedures.html#%28def._%28%28lib._racket%2Fprivate%2Flist..rkt%29._compose1%29%29) favors `compose1`.