### PR TITLE
Fix minor typo in Pollen docs

### DIFF
--- a/pollen/scribblings/programming-pollen.scrbl
+++ b/pollen/scribblings/programming-pollen.scrbl
@@ -83,6 +83,10 @@ This refers to the function as a value (not usually what you want):
 
 I want to attend ◊em{RacketCon ◊strong{this} year}.}]
 
+Yielding:
+
+@repl-output{'(root "I want to attend " (em "RacketCon " "BAP" " year") ".")}
+
 @subsection{Multiple input values & rest arguments} Sometimes a tag will have only one word or string that becomes its input. More likely, however, it will have multiple values (this is inevitable with nested tags, because the results aren't concatenated). For instance, if we attach our function to @racket[em] rather than @racket[strong]:
 
 @fileblock["article.html.pm" @codeblock{

--- a/pollen/scribblings/tutorial-third.scrbl
+++ b/pollen/scribblings/tutorial-third.scrbl
@@ -522,7 +522,7 @@ This code would not, however, produce an error if it were being run as a Pollen 
 
 As you get more comfortable attaching behavior to tags using tag functions, you'll likely want to create some functions that can be shared between multiple source files. The @filepath{pollen.rkt} file is a special file that is automatically imported by Pollen source files in the same directory (including subdirectories). So every function and value provided by @filepath{pollen.rkt} can be used in these Pollen files.
 
-First, using @filepath{pollen.rkt} isn't mandatory. Within a Pollen source file, you can always import functions and values with @racket[require] (as seen in the previous section). @filepath{pollen.rkt} just makes it easier to propagate a set of common definitions to every every Pollen source file in your project.
+First, using @filepath{pollen.rkt} isn't mandatory. Within a Pollen source file, you can always import functions and values with @racket[require] (as seen in the previous section). @filepath{pollen.rkt} just makes it easier to propagate a set of common definitions to every Pollen source file in your project.
 
 Second, notice from the @filepath{.rkt} suffix that @filepath{pollen.rkt} is a source file containing Racket code, not Pollen code. This is the default because while Pollen's notation is more convenient for text-based source files, Racket's notation is more convenient when you're just dealing with code.
 


### PR DESCRIPTION
Also, clarify one example by showing the resulting output from Pollen.

Change-Id: I4ee1794091ed5f0b7170450554f50e6135d6a56f