### PR TITLE
Fix `when/splice' inconsistent return types

### DIFF
--- a/pollen/core.rkt
+++ b/pollen/core.rkt
@@ -121,7 +121,7 @@
        #'(if COND
              (with-handlers ([exn:fail? (λ(exn) (error (format "within when/splice, ~a" (exn-message exn))))])
                (SPLICING-TAG BODY ...)) 
-             ""))]))
+             '()))]))
 
 
 (provide when/block) ; bw compat


### PR DESCRIPTION
**CURRENT BEHAVIOR**

The function `when/splice` returns either a list (when the condition is true), or a string (when the condition is false). This makes it unusable in contexts that expect lists—for example, `(... ,@◊when/splice[...]{...} ...)`.

**EXPECTED BEHAVIOR**

The return types of `when/splice` are consistent. When the condition is false, return an empty list.