### PR TITLE
Extend #lang pollen’s get-info function to communicate file extensions

### DIFF
--- a/pollen/private/reader-base.rkt
+++ b/pollen/private/reader-base.rkt
@@ -88,6 +88,10 @@
             (my-make-drracket-buttons my-command-char)])]
         [(drracket:indentation)
          (dynamic-require 'scribble/private/indentation 'determine-spaces)]
+        [(drracket:default-extension)
+         "pm"]
+        [(drracket:default-filters)
+         '(["Pollen Sources" "*.p;*.pp;*.pmd;*.pm;*.ptree"])]
         [else default]))))
 
 (define-syntax-rule (reader-module-begin mode expr-to-ignore ...)


### PR DESCRIPTION
With this change, files with `#lang pollen` at the top will default to `Untitled.pm` instead of `Untitled.rkt` when saving them for the first time in DrRacket, and it will not append `.rkt` to files saved with `.pp`, `.pmd`, or `.pm` extensions.