### PR TITLE
fix the problem of fail to render non-html output format in project s…

### DIFF
--- a/pollen/render.rkt
+++ b/pollen/render.rkt
@@ -195,10 +195,14 @@
 
 (define+provide/contract (render-from-source-or-output-path so-pathish)
   (pathish? . -> . void?)
-  (match (->complete-path so-pathish)
-    [(app ->source-path (and (not #false) source-path)) (render-to-file-if-needed source-path)]
-    [(? pagetree-source? pt) (render-pagenodes pt)]
-    [_ (void)]))
+  (let ((complete-path (->complete-path so-pathish)))
+    (match complete-path
+      [(app ->source-path (and (not #false) source-path))
+       (if (string=? (->string source-path) (->string complete-path))
+           (render-to-file-if-needed source-path)
+           (render-to-file-if-needed source-path #f complete-path))]
+      [(? pagetree-source? pt) (render-pagenodes pt)]
+      [_ (void)])))
 
 (define render-ram-cache (make-hash))
 


### PR DESCRIPTION
1. Create directory with:
/tmp/x4 rshen @ pc13f ᐅ ls
cv.poly.pm     pollen.rkt     template.ltx.p template.txt.p

/tmp/x4 rshen @ pc13f ᐅ cat cv.poly.pm
#lang pollen

◊heading{Brennan Huff}

Today is ◊(get-date). I ◊emph{really} want this job.

Yes, this is the worst résumé ever. Yours, I’m certain, would be better.

See you.

/tmp/x4 rshen @ pc13f ᐅ cat pollen.rkt
#lang racket/base
(require racket/date txexpr pollen/setup)
(provide (all-defined-out))

(module setup racket/base
  (provide (all-defined-out))
  (define poly-targets '(html txt ltx)))

(define (get-date)
  (date->string (current-date)))

(define (heading . elements)
  (case (current-poly-target)
    [(ltx) (apply string-append `("{\\huge " ,@elements "}"))]
    [(txt) (map string-upcase elements)]
    [else (txexpr 'h2 empty elements)]))

(define (emph . elements)
  (case (current-poly-target)
    [(ltx) (apply string-append `("{\\bf " ,@elements "}"))]
    [(txt) `("**" ,@elements "**")]
    [else (txexpr 'strong empty elements)]))
/tmp/x4 rshen @ pc13f ᐅ cat template.ltx.p
\documentclass[a4paper,12pt]{letter}
\begin{document}
◊(local-require racket/list)
◊(apply string-append (filter string? (flatten doc)))
\end{document}

/tmp/x4 rshen @ pc13f ᐅ cat template.txt.p
◊(local-require racket/list)
◊(apply string-append (filter string? (flatten doc)))

2. start server

3. open http://localhost:8080/index.ptree

4. click cv.txt

5. get following in console
....
pollen: /cv.txt
pollen: rendering /cv.poly.pm as html
pollen: rendered /cv.html (347 ms)
pollen: can't find /cv.txt
pollen: /error.css

6. also 404 error in browser
