### PR TITLE
start command: fix default value for port

### DIFF
--- a/pollen/private/command.rkt
+++ b/pollen/private/command.rkt
@@ -182,13 +182,13 @@ version                print the version" (current-server-port) (make-publish-di
      #:once-each
      [("--launch" "-l") "Launch browser after start" (set! launch-wanted #t)]
      [("--local") "Restrict access to localhost" (set! localhost-wanted #t)]
-     #:args ([dir (current-directory)] [port "8080"])
+     #:args ([dir (current-directory)] [port #f])
      (define parsed-dir
        (path->directory-path (normalize-path (very-nice-path dir))))
      (unless (directory-exists? parsed-dir)
        (error (format "~a is not a directory" parsed-dir)))
 
-     (define parsed-port (string->number port))
+     (define parsed-port (and port (string->number port)))
      (when (and parsed-port (not (exact-positive-integer? parsed-port)))
        (error (format "~a is not a valid port number" parsed-port)))
      (values parsed-dir parsed-port)))

--- a/pollen/test/data/project-port/hello.txt.pp
+++ b/pollen/test/data/project-port/hello.txt.pp
@@ -1,0 +1,3 @@
+#lang pollen
+
+Hello!

--- a/pollen/test/data/project-port/pollen.rkt
+++ b/pollen/test/data/project-port/pollen.rkt
@@ -1,0 +1,6 @@
+#lang racket/base
+
+(module setup racket/base
+  (provide (all-defined-out))
+  (define project-server-port
+    9876))

--- a/pollen/test/test-project-port.rkt
+++ b/pollen/test/test-project-port.rkt
@@ -1,0 +1,36 @@
+#lang racket/base
+
+(require rackunit
+         racket/port
+         racket/runtime-path)
+
+(define-runtime-path project-port-dir "data/project-port")
+
+(define thd #f)
+(define-values (in out) (make-pipe))
+(parameterize ([exit-handler (lambda (code)
+                               (fail (format "abnormal exit from raco command~n  code: ~a" code))
+                               (kill-thread thd))])
+  (set! thd
+        (parameterize ([current-output-port out]
+                       [current-error-port out]
+                       [current-directory project-port-dir]
+                       [current-command-line-arguments (vector "start")])
+          (thread
+           (lambda ()
+             (dynamic-require '(submod pollen/private/command raco) #f)))))
+
+  (dynamic-wind
+    void
+    (lambda ()
+      (sync
+       (handle-evt
+        (regexp-match-evt #rx"project server is http://localhost:9876" in)
+        void)
+       (handle-evt
+        (alarm-evt (+ (current-inexact-milliseconds) 5000))
+        (lambda (_)
+          (fail "timed out while waiting for server to start")))))
+    (lambda ()
+      (break-thread thd)
+      (thread-wait thd))))

--- a/pollen/test/test-project-port.rkt
+++ b/pollen/test/test-project-port.rkt
@@ -1,36 +1,51 @@
 #lang racket/base
 
-(require rackunit
-         racket/port
-         racket/runtime-path)
+(require racket/port
+         racket/runtime-path
+         racket/tcp
+         rackunit)
 
 (define-runtime-path project-port-dir "data/project-port")
 
-(define thd #f)
-(define-values (in out) (make-pipe))
-(parameterize ([exit-handler (lambda (code)
-                               (fail (format "abnormal exit from raco command~n  code: ~a" code))
-                               (kill-thread thd))])
-  (set! thd
-        (parameterize ([current-output-port out]
-                       [current-error-port out]
-                       [current-directory project-port-dir]
-                       [current-command-line-arguments (vector "start")])
-          (thread
-           (lambda ()
-             (dynamic-require '(submod pollen/private/command raco) #f)))))
+(define the-port
+  (dynamic-require
+   `(submod ,(build-path project-port-dir "pollen.rkt") setup)
+   'project-server-port))
 
-  (dynamic-wind
-    void
-    (lambda ()
-      (sync
-       (handle-evt
-        (regexp-match-evt #rx"project server is http://localhost:9876" in)
-        void)
-       (handle-evt
-        (alarm-evt (+ (current-inexact-milliseconds) 5000))
-        (lambda (_)
-          (fail "timed out while waiting for server to start")))))
-    (lambda ()
-      (break-thread thd)
-      (thread-wait thd))))
+(define-values (in out)
+  (make-pipe))
+
+(define thd
+  (parameterize ([current-output-port out]
+                 [current-error-port out]
+                 [current-directory project-port-dir]
+                 [current-command-line-arguments (vector "start")]
+                 [exit-handler (lambda (code)
+                                 (fail (format "abnormal exit from raco command~n  code: ~a" code))
+                                 (kill-thread thd))])
+    (thread
+     (lambda ()
+       (dynamic-require '(submod pollen/private/command raco) #f)))))
+
+(dynamic-wind
+  void
+  (lambda ()
+    (sync
+     (handle-evt
+      (regexp-match-evt #rx"ready to rock" in)
+      void)
+     (handle-evt
+      (alarm-evt (+ (current-inexact-milliseconds) 5000))
+      (lambda (_)
+        (fail "timed out while waiting for server to start"))))
+
+    (with-handlers ([exn:fail?
+                     (lambda (e)
+                       (fail (format "failed to connect to server: ~a" (exn-message e))))])
+      (define-values (cin cout)
+        (tcp-connect "127.0.0.1" the-port))
+      (close-output-port cout)
+      (close-input-port cin)))
+  (lambda ()
+    (break-thread thd)
+    (thread-wait thd)))


### PR DESCRIPTION
I noticed I made a mistake in my change from yesterday. Defaulting the port to "8080" at the `command-line` level is wrong because it makes it impossible to set a custom port via a `setup` submodule in `pollen.rkt`.