### PR TITLE
Clarifications for `raco pollen render` (fixes #248)

### DIFF
--- a/pollen/scribblings/raco.scrbl
+++ b/pollen/scribblings/raco.scrbl
@@ -102,7 +102,9 @@ Paths can also be specified as output rather than input paths, and the correspon
 > raco pollen render foo.html
 > raco pollen render foo.html bar.html zam.css}
 
-The optional @exec{--target} or @exec{-t} switch specifies the render target for multi-output source files. If the target is omitted, the renderer will use whatever target appears first in @racket[(setup:poly-targets)].
+If a pagetree file is included in @racket[_source], all the files it lists will be rendered using the above rules.
+
+The optional @exec{--target} or @exec{-t} switch specifies the render target to use for multi-output source files. (Files of other types encountered in @racket[_source] will still be rendered as usual.) If the target is omitted, the renderer will use whatever target appears first in @racket[(setup:poly-targets)].
 
 @terminal{
 > raco pollen render -t pdf foo.poly.pm}
@@ -130,7 +132,7 @@ As a rule of thumb, parallel rendering works best if you do @exec{raco setup} fi
 
 @italic{Warning}: In all cases, the newly rendered output file will overwrite any previous output file.
 
-@bold{Directory mode}: @racket[raco pollen render _directory] renders all preprocessor source files and then all pagetree files found in the specified directory. If none of these files are found, a pagetree will be generated for the directory (which will include all source files) and then rendered. If the @racket[_directory] argument is omitted, the command defaults to the current directory.
+@bold{Directory mode}: @racket[raco pollen render _directory] renders all preprocessor source files and then all pagetree files found in the specified directory. If none of these files are found, a pagetree will be generated for the directory (which will include all source files, but also everything else that exists there; see @secref["The_automatic_pagetree"]) and then rendered. If the @racket[_directory] argument is omitted, the command defaults to the current directory.
 
 In directory mode, this command can be invoked with two other optional arguments (in addition to the @exec{--target}, @exec{--parallel}, and  @exec{--jobs} switches mentioned above):
 


### PR DESCRIPTION
I don’t think we need an additional command line switch, so the simplest fix is to make a few things more explicit in the docs.